### PR TITLE
Bind Python version to >=3.11,<4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "trecvit"
 version = "0.1.0"
+requires-python = ">=3.11,<4.0"
 description = "TRecViT codebase from Google DeepMind."
 dependencies = [
 


### PR DESCRIPTION
 Bind Python version to >=3.11,<4.0 since recurrentgemma requires Python >=3.11,<4.0